### PR TITLE
Pass serial style when creating zones

### DIFF
--- a/src/TrafficManagement.php
+++ b/src/TrafficManagement.php
@@ -227,7 +227,8 @@ class TrafficManagement
 
         $params = array(
             'rname' => $rname,
-            'ttl' => $defaultTtl
+            'ttl' => $defaultTtl,
+            'serial_style' => $serialStyle
         );
 
         $result = $this->apiClient->post('/Zone/'.$zoneName, $params);


### PR DESCRIPTION
The serial style was not being passed when creating a zone, so it was defaulting to increment.
