### PR TITLE
error checking for httpclient

### DIFF
--- a/src/TrafficManagement.php
+++ b/src/TrafficManagement.php
@@ -55,7 +55,7 @@ class TrafficManagement
         $this->username = $username;
         $this->password = $password;
 
-        if ($this->httpClient) {
+        if ($httpClient) {
             $this->httpClient = $httpClient;
         }
     }


### PR DESCRIPTION
Traffic management was checking the wong value on __construct, so you could never set the httpClient, which lets you set options sslcacertpath etc..