### PR TITLE
Implement DKIM in MessageManagement API

### DIFF
--- a/src/MessageManagement.php
+++ b/src/MessageManagement.php
@@ -162,9 +162,9 @@ class MessageManagement
 
     /**
      * Returns the senders API resource instance, creating it if required.
-     * Used for all suppression list related API functionality.
+     * Used for all sender related API functionality.
      *
-     * @return SuppressionList
+     * @return Senders
      */
     public function senders()
     {

--- a/src/MessageManagement/Api/Resource/Senders.php
+++ b/src/MessageManagement/Api/Resource/Senders.php
@@ -4,6 +4,8 @@ namespace Dyn\MessageManagement\Api\Resource;
 
 use DateTime;
 use Dyn\MessageManagement\Sender;
+use Dyn\MessageManagement\Api\Resource\Senders\Status;
+use Dyn\MessageManagement\Api\Resource\Senders\Details;
 
 class Senders extends AbstractResource
 {
@@ -13,7 +15,7 @@ class Senders extends AbstractResource
      * @param  integer $startIndex Optional start index
      * @return array|false
      */
-    public function get($startIndex = 0)
+    public function get($startIndex = 0, $extras=[])
     {
         $params = array();
         if ($startIndex) {
@@ -28,6 +30,16 @@ class Senders extends AbstractResource
             foreach ($response->data->senders as $senderData) {
                 $sender = new Sender();
                 $sender->setEmailAddress($senderData->emailaddress);
+
+                if (in_array('status', $extras)) {
+                    $status = new Status();
+                    $status->get($sender);
+                }
+
+                if (in_array('details', $extras)) {
+                    $details = new Details();
+                    $details->get($sender);
+                }
 
                 $senders[] = $sender;
             }

--- a/src/MessageManagement/Api/Resource/Senders.php
+++ b/src/MessageManagement/Api/Resource/Senders.php
@@ -32,12 +32,12 @@ class Senders extends AbstractResource
                 $sender->setEmailAddress($senderData->emailaddress);
 
                 if (in_array('status', $extras)) {
-                    $status = new Status();
+                    $status = new Status($this->getApiClient());
                     $status->get($sender);
                 }
 
                 if (in_array('details', $extras)) {
-                    $details = new Details();
+                    $details = new Details($this->getApiClient());
                     $details->get($sender);
                 }
 

--- a/src/MessageManagement/Api/Resource/Senders.php
+++ b/src/MessageManagement/Api/Resource/Senders.php
@@ -11,13 +11,16 @@ use Dyn\MessageManagement\Api\Resource\Senders\Dkim;
 class Senders extends AbstractResource
 {
 
+    /**
+     * @var Dkim
+     */
     protected $dkim = null;
-
 
     /**
      * Returns up to 25 approved senders
      *
      * @param  integer $startIndex Optional start index
+     * @param  array $extras Optional list of extras to fetch {status,details}
      * @return array|false
      */
     public function get($startIndex = 0, $extras=[])
@@ -55,6 +58,11 @@ class Senders extends AbstractResource
         return false;
     }
 
+    /**
+     * Return an instance of the Dkim API Resource
+     * 
+     * @return Dkim $dkim
+     */
     public function dkim()
     {
         if ($this->dkim === null) {

--- a/src/MessageManagement/Api/Resource/Senders.php
+++ b/src/MessageManagement/Api/Resource/Senders.php
@@ -6,9 +6,14 @@ use DateTime;
 use Dyn\MessageManagement\Sender;
 use Dyn\MessageManagement\Api\Resource\Senders\Status;
 use Dyn\MessageManagement\Api\Resource\Senders\Details;
+use Dyn\MessageManagement\Api\Resource\Senders\Dkim;
 
 class Senders extends AbstractResource
 {
+
+    protected $dkim = null;
+
+
     /**
      * Returns up to 25 approved senders
      *
@@ -48,6 +53,15 @@ class Senders extends AbstractResource
         }
 
         return false;
+    }
+
+    public function dkim()
+    {
+        if ($this->dkim === null) {
+            $this->dkim = new Dkim($this->getApiClient());
+        }
+
+        return $this->dkim;
     }
 
     /**

--- a/src/MessageManagement/Api/Resource/Senders/Details.php
+++ b/src/MessageManagement/Api/Resource/Senders/Details.php
@@ -1,0 +1,25 @@
+<?php 
+
+namespace Dyn\MessageManagement\Api\Resource\Senders;
+
+use \Dyn\MessageManagement\Sender;
+
+class Details extends \Dyn\MessageManagement\Api\Resource\AbstractResource {
+
+    public function get(Sender $sender)
+    {
+        $params = array(
+            'emailaddress' => $sender->getEmailAddress()
+        );
+
+        $response = $this->getApiClient()->get('/senders/details', $params);
+        if ($response && $response->isOK()) {
+            $sender->setDetails($response->data);
+
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/src/MessageManagement/Api/Resource/Senders/Details.php
+++ b/src/MessageManagement/Api/Resource/Senders/Details.php
@@ -7,6 +7,12 @@ use \Dyn\MessageManagement\Api\Resource\AbstractResource;
 
 class Details extends AbstractResource {
 
+    /**
+     * Gets details for sender and writes it to the provided instance of Sender
+     *
+     * @param Sender $sender
+     * @return boolean
+     */
     public function get(Sender $sender)
     {
         $params = array(

--- a/src/MessageManagement/Api/Resource/Senders/Details.php
+++ b/src/MessageManagement/Api/Resource/Senders/Details.php
@@ -3,8 +3,9 @@
 namespace Dyn\MessageManagement\Api\Resource\Senders;
 
 use \Dyn\MessageManagement\Sender;
+use \Dyn\MessageManagement\Api\Resource\AbstractResource;
 
-class Details extends \Dyn\MessageManagement\Api\Resource\AbstractResource {
+class Details extends AbstractResource {
 
     public function get(Sender $sender)
     {

--- a/src/MessageManagement/Api/Resource/Senders/Dkim.php
+++ b/src/MessageManagement/Api/Resource/Senders/Dkim.php
@@ -8,6 +8,13 @@ use \Dyn\MessageManagement\Api\Resource\Senders\Details;
 
 class Dkim extends AbstractResource {
 
+    /**
+     * Create DKIM selector, optionally using the provided selector
+     *
+     * @param Sender $sender
+     * @param string $dkimIdentifier Optional selector to assign to domain's DKIM
+     * @return boolean
+     */
     public function create(Sender $sender, $dkimIdentifier=false)
     {
         if (false === $dkimIdentifier) {
@@ -19,6 +26,9 @@ class Dkim extends AbstractResource {
             'dkim' => $dkimIdentifier
         );
 
+        // Assignment of a new selector should be rare and we're extremely likely
+        // to want the public keys after, so we'll go ahead and refresh details which
+        // which contain the DKIM records
         $response = $this->getApiClient()->post('/senders/dkim', $params);
         if ($response && $response->isOK()) {
             $details = new Details($this->getApiClient());

--- a/src/MessageManagement/Api/Resource/Senders/Dkim.php
+++ b/src/MessageManagement/Api/Resource/Senders/Dkim.php
@@ -10,17 +10,18 @@ class Dkim extends AbstractResource {
 
     public function create(Sender $sender, $dkimIdentifier=false)
     {
-        $params = array(
-            'emailaddress' => $sender->getEmailAddress()
-        );
-
         if (false === $dkimIdentifier) {
             $dkimIdentifier = uniqid();
         }
 
+        $params = array(
+            'emailaddress' => $sender->getEmailAddress(),
+            'dkim' => $dkimIdentifier
+        );
+
         $response = $this->getApiClient()->post('/senders/dkim', $params);
         if ($response && $response->isOK()) {
-            $details = new Details();
+            $details = new Details($this->getApiClient());
             $details->get($sender);
             return true;
         }

--- a/src/MessageManagement/Api/Resource/Senders/Dkim.php
+++ b/src/MessageManagement/Api/Resource/Senders/Dkim.php
@@ -1,0 +1,31 @@
+<?php 
+
+namespace Dyn\MessageManagement\Api\Resource\Senders;
+
+use \Dyn\MessageManagement\Sender;
+use \Dyn\MessageManagement\Api\Resource\AbstractResource;
+use \Dyn\MessageManagement\Api\Resource\Senders\Details;
+
+class Dkim extends AbstractResource {
+
+    public function create(Sender $sender, $dkimIdentifier=false)
+    {
+        $params = array(
+            'emailaddress' => $sender->getEmailAddress()
+        );
+
+        if (false === $dkimIdentifier) {
+            $dkimIdentifier = uniqid();
+        }
+
+        $response = $this->getApiClient()->post('/senders/dkim', $params);
+        if ($response && $response->isOK()) {
+            $details = new Details();
+            $details->get($sender);
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/src/MessageManagement/Api/Resource/Senders/Status.php
+++ b/src/MessageManagement/Api/Resource/Senders/Status.php
@@ -1,0 +1,25 @@
+<?php 
+
+namespace Dyn\MessageManagement\Api\Resource\Senders;
+
+use \Dyn\MessageManagement\Sender;
+
+class Status extends \Dyn\MessageManagement\Api\Resource\AbstractResource {
+
+    public function get(Sender $sender)
+    {
+        $params = array(
+            'emailaddress' => $sender->getEmailAddress()
+        );
+
+        $response = $this->getApiClient()->get('/senders/status', $params);
+        if ($response && $response->isOK()) {
+            $sender->setIsReady((bool)$response->data->ready);
+    
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/src/MessageManagement/Api/Resource/Senders/Status.php
+++ b/src/MessageManagement/Api/Resource/Senders/Status.php
@@ -3,8 +3,9 @@
 namespace Dyn\MessageManagement\Api\Resource\Senders;
 
 use \Dyn\MessageManagement\Sender;
+use \Dyn\MessageManagement\Api\Resource\AbstractResource;
 
-class Status extends \Dyn\MessageManagement\Api\Resource\AbstractResource {
+class Status extends AbstractResource {
 
     public function get(Sender $sender)
     {

--- a/src/MessageManagement/Api/Resource/Senders/Status.php
+++ b/src/MessageManagement/Api/Resource/Senders/Status.php
@@ -7,6 +7,12 @@ use \Dyn\MessageManagement\Api\Resource\AbstractResource;
 
 class Status extends AbstractResource {
 
+    /**
+     * Get status of the sender and assign to provided instance of Sender
+     *
+     * @param Sender $sender
+     * @return boolean
+     */
     public function get(Sender $sender)
     {
         $params = array(

--- a/src/MessageManagement/Sender.php
+++ b/src/MessageManagement/Sender.php
@@ -9,6 +9,11 @@ class Sender
      */
     protected $emailAddress;
 
+    /**
+     * @var bool
+     */
+    protected $isReady;
+
 
     /**
      * Setter for email address
@@ -30,5 +35,69 @@ class Sender
     public function getEmailAddress()
     {
         return $this->emailAddress;
+    }
+
+    /**
+     * Setter for isReady (from /senders/status)
+     *
+     * @param bool $isReady
+     */
+    public function setIsReady($isReady)
+    {
+        $this->isReady = $isReady;
+
+        return $this;
+    }
+
+    /**
+     * Getter for isReady (from /senders/status)
+     *
+     * @return bool
+     */
+    public function isReady()
+    {
+        return $this->isReady;
+    }
+
+    /**
+     * Setter for details about the sender
+     *
+     * @param stdClass $details
+     */
+    public function setDetails($details)
+    {
+        $this->details = $details;
+
+        return $this;
+    }
+
+    /**
+     * Getter for dkimIsVerified (inside details)
+     *
+     * @return bool $dkimIsVerified
+     */
+    public function dkimIsVerified()
+    {
+        return (bool)$this->details->dkim;
+    }
+
+    /**
+     * Getter for dkimValue (inside details)
+     *
+     * @return string $dkimValue
+     */
+    public function getDkimValue()
+    {
+        return $this->details->dkimval;
+    }
+
+    /**
+     * Getter for spfIsVerified (inside details)
+     * 
+     * @return bool $spfIsVerified
+     */
+    public function spfIsVerified()
+    {
+        return (bool)$this->details->spf;
     }
 }

--- a/src/MessageManagement/Sender.php
+++ b/src/MessageManagement/Sender.php
@@ -102,10 +102,15 @@ class Sender
         $domain = substr($email, strpos($email, '@')+1);
         $domainKeyDomain = '_domainkey.' . $domain;
         $selectorRecord = $this->getDkimIdentifier() . '.' . $domainKeyDomain;
-        return [
-            $selectorRecord => $this->details->$selectorRecord,
-            $domainKeyDomain => $this->details->$domainKeyDomain
-        ];
+
+        if ($this->getDkimIdentifier() !== "" && property_exists($this->details, $selectorRecord) && property_exists($this->details, $domainKeyDomain)) {
+            return [
+                $selectorRecord => $this->details->$selectorRecord,
+                $domainKeyDomain => $this->details->$domainKeyDomain
+            ];
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/MessageManagement/Sender.php
+++ b/src/MessageManagement/Sender.php
@@ -86,9 +86,26 @@ class Sender
      *
      * @return string $dkimValue
      */
-    public function getDkimValue()
+    public function getDkimIdentifier()
     {
         return $this->details->dkimval;
+    }
+
+    /**
+     * Getter for DKIM DNS Records
+     *
+     * @return array $dkimRecords
+     */
+    public function getDkimRecords()
+    {
+        $email = $this->getEmailAddress();
+        $domain = substr($email, strpos($email, '@')+1);
+        $domainKeyDomain = '_domainkey.' . $domain;
+        $selectorRecord = $this->getDkimIdentifier() . '.' . $domainKeyDomain;
+        return [
+            $selectorRecord => $this->details->$selectorRecord,
+            $domainKeyDomain => $this->details->$domainKeyDomain
+        ];
     }
 
     /**

--- a/test/DynTest/MessageManagement/Api/Resource/Senders/DetailsTest.php
+++ b/test/DynTest/MessageManagement/Api/Resource/Senders/DetailsTest.php
@@ -32,12 +32,14 @@ class DetailsTest extends PHPUnit_Framework_TestCase
         $this->details->getApiClient()->getHttpClient()->getAdapter()->setResponse(
 "HTTP/1.1 200 OK" . "\r\n" .
 "Content-type: application/json" . "\r\n\r\n" .
-'{"response":{"status":200,"message":"OK","data":{"emailaddress":"example@domain.com","spf":1,"dkim":1,"dkimval":"private"}}}'
+'{"response":{"status":200,"message":"OK","data":{"emailaddress":"example@domain.com","spf":1,"dkim":1,"dkimval":"private","private._domainkey.example.org":"fakekey","_domainkey.example.org":"fakedkim"}}}'
         );
 
         $details = $this->details->get($this->sender);
 
-        $this->assertEquals('private', $this->sender->getDkimValue());
+        $this->assertEquals('private', $this->sender->getDkimIdentifier());
+        $this->assertInternalType('array', $this->sender->getDkimRecords());
+        $this->assertEquals(2,count($this->sender->getDkimRecords()));
         $this->assertTrue($this->sender->dkimIsVerified());
         $this->assertTrue($this->sender->spfIsVerified());
     }

--- a/test/DynTest/MessageManagement/Api/Resource/Senders/DetailsTest.php
+++ b/test/DynTest/MessageManagement/Api/Resource/Senders/DetailsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DynTest\MessageManagement\Api\Resource\Senders;
+
+use PHPUnit_Framework_TestCase;
+use DynTest\TestBootstrap;
+use Dyn\MessageManagement\Api\Resource\Senders\Details;
+use Dyn\MessageManagement\Sender;
+
+class DetailsTest extends PHPUnit_Framework_TestCase
+{
+    protected $sender;
+    protected $details;
+
+    public function setUp()
+    {
+        $apiClient = TestBootstrap::getTestMMApiClient();
+        $apiClient->setApiKey('xxxxxxxxxxxx');
+
+        $this->sender = new Sender();
+        $this->sender->setEmailAddress('test1@example.org');
+        $this->details = new Details($apiClient);
+    }
+
+    public function testSenderDetails()
+    {
+        $apiKey = 'notarealapikey';
+
+        $this->details->getApiClient()->setApiKey($apiKey);
+
+        // simulate the Dyn API response
+        $this->details->getApiClient()->getHttpClient()->getAdapter()->setResponse(
+"HTTP/1.1 200 OK" . "\r\n" .
+"Content-type: application/json" . "\r\n\r\n" .
+'{"response":{"status":200,"message":"OK","data":{"emailaddress":"example@domain.com","spf":1,"dkim":1,"dkimval":"private"}}}'
+        );
+
+        $details = $this->details->get($this->sender);
+
+        $this->assertEquals('private', $this->sender->getDkimValue());
+        $this->assertTrue($this->sender->dkimIsVerified());
+        $this->assertTrue($this->sender->spfIsVerified());
+    }
+
+}

--- a/test/DynTest/MessageManagement/Api/Resource/Senders/StatusTest.php
+++ b/test/DynTest/MessageManagement/Api/Resource/Senders/StatusTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace DynTest\MessageManagement\Api\Resource\Senders;
+
+use PHPUnit_Framework_TestCase;
+use DynTest\TestBootstrap;
+use Dyn\MessageManagement\Api\Resource\Senders\Status;
+use Dyn\MessageManagement\Sender;
+
+class StatusTest extends PHPUnit_Framework_TestCase
+{
+    protected $sender;
+    protected $status;
+
+    public function setUp()
+    {
+        $apiClient = TestBootstrap::getTestMMApiClient();
+        $apiClient->setApiKey('xxxxxxxxxxxx');
+
+        $this->sender = new Sender();
+        $this->sender->setEmailAddress('test1@example.org');
+        $this->status = new Status($apiClient);
+    }
+
+    public function testSenderIsReady()
+    {
+        $apiKey = 'notarealapikey';
+
+        $this->status->getApiClient()->setApiKey($apiKey);
+
+        // simulate the Dyn API response
+        $this->status->getApiClient()->getHttpClient()->getAdapter()->setResponse(
+"HTTP/1.1 200 OK" . "\r\n" .
+"Content-type: application/json" . "\r\n\r\n" .
+'{"response":{"status":200,"message":"OK","data":{"ready":1}}}'
+        );
+
+        $status = $this->status->get($this->sender);
+
+        $this->assertInternalType('bool', $status);
+        $this->assertTrue($this->sender->isReady());
+    }
+
+    public function testSenderNotReady()
+    {
+        $apiKey = 'notarealapikey';
+
+        $this->status->getApiClient()->setApiKey($apiKey);
+
+        // simulate the Dyn API response
+        $this->status->getApiClient()->getHttpClient()->getAdapter()->setResponse(
+"HTTP/1.1 200 OK" . "\r\n" .
+"Content-type: application/json" . "\r\n\r\n" .
+'{"response":{"status":200,"message":"OK","data":{"ready":0}}}'
+        );
+
+        $status = $this->status->get($this->sender);
+
+        $this->assertInternalType('bool', $status);
+        $this->assertFalse($this->sender->isReady());
+    }
+
+}

--- a/test/DynTest/MessageManagement/Api/Resource/SendersTest.php
+++ b/test/DynTest/MessageManagement/Api/Resource/SendersTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace DynTest\MessageManagement\Api\Resource;
+
+use PHPUnit_Framework_TestCase;
+use DynTest\TestBootstrap;
+use Dyn\MessageManagement\Api\Resource\Senders;
+use Dyn\MessageManagement\Sender;
+
+class SendersTest extends PHPUnit_Framework_TestCase
+{
+    protected $senders;
+
+    public function setUp()
+    {
+        $apiClient = TestBootstrap::getTestMMApiClient();
+        $apiClient->setApiKey('xxxxxxxxxxxx');
+
+        $this->senders = new Senders($apiClient);
+    }
+
+    public function testGetWithMultipleResults()
+    {
+        $apiKey = 'notarealapikey';
+
+        $this->senders->getApiClient()->setApiKey($apiKey);
+
+        // simulate the Dyn API response
+        $this->senders->getApiClient()->getHttpClient()->getAdapter()->setResponse(
+"HTTP/1.1 200 OK" . "\r\n" .
+"Content-type: application/json" . "\r\n\r\n" .
+'{"response":{"status":200,"message":"OK","data":{"senders":[{"emailaddress":"email1@example.org"},{"emailaddress":"email2@example.com"}]}}}'
+        );
+
+        $senders = $this->senders->get();
+
+        $this->assertInternalType('array', $senders);
+
+        foreach ($senders as $sender) {
+            $this->assertInstanceOf('Dyn\MessageManagement\Sender', $sender);
+            $this->assertTrue((in_array($sender->getEmailAddress(),array('email1@example.org','email2@example.com'))));
+        }
+    }
+/*
+    public function testCreate()
+    {
+        // simulate the Dyn API response
+        $this->accounts->getApiClient()->getHttpClient()->getAdapter()->setResponse(
+"HTTP/1.1 200 OK" . "\r\n" .
+"Content-type: application/json" . "\r\n\r\n" .
+'{"response":{"status":200,"message":"OK","data":{"apikey": "abcdefghijklmnopqrstuvwxyz"}}}'
+        );
+
+        $account = new Account();
+        $account->setUsername('user@example.com')
+                ->setPassword('notarealpassword')
+                ->setCompanyName('Dyn')
+                ->setPhone('603-123-1234');
+
+        $result = $this->accounts->create($account);
+
+        $this->assertInstanceOf('Dyn\MessageManagement\Account', $result);
+        $this->assertEquals('abcdefghijklmnopqrstuvwxyz', $account->getApiKey());
+    }
+
+*/
+}

--- a/test/DynTest/MessageManagement/Api/Resource/SendersTest.php
+++ b/test/DynTest/MessageManagement/Api/Resource/SendersTest.php
@@ -41,27 +41,4 @@ class SendersTest extends PHPUnit_Framework_TestCase
             $this->assertTrue((in_array($sender->getEmailAddress(),array('email1@example.org','email2@example.com'))));
         }
     }
-/*
-    public function testCreate()
-    {
-        // simulate the Dyn API response
-        $this->accounts->getApiClient()->getHttpClient()->getAdapter()->setResponse(
-"HTTP/1.1 200 OK" . "\r\n" .
-"Content-type: application/json" . "\r\n\r\n" .
-'{"response":{"status":200,"message":"OK","data":{"apikey": "abcdefghijklmnopqrstuvwxyz"}}}'
-        );
-
-        $account = new Account();
-        $account->setUsername('user@example.com')
-                ->setPassword('notarealpassword')
-                ->setCompanyName('Dyn')
-                ->setPhone('603-123-1234');
-
-        $result = $this->accounts->create($account);
-
-        $this->assertInstanceOf('Dyn\MessageManagement\Account', $result);
-        $this->assertEquals('abcdefghijklmnopqrstuvwxyz', $account->getApiKey());
-    }
-
-*/
 }


### PR DESCRIPTION
Greetings,

I implemented DKIM provisioning in the SDK.  It was also necessary to implement the "sender/details" API.  "sender/status" was a bonus.

I added a couple tests for the new calls as well.

Here's a quick sample:
```php
$senders = $this->DynMM->senders()->get();
foreach ($senders as $sender) {
    $this->DynMM->senders()->dkim()->create($sender);
    $dkimRecords = $sender->getDkimRecords();
}
```