### PR TITLE
Typo during --optimize

### DIFF
--- a/src/TrafficManagement/Record/PX.php
+++ b/src/TrafficManagement/Record/PX.php
@@ -2,7 +2,7 @@
 
 namespace Dyn\TrafficManagement\Record;
 
-class NAPTR extends AbstractRecord
+class PX extends AbstractRecord
 {
     /**
      * @var string

--- a/src/TrafficManagement/Record/SPF.php
+++ b/src/TrafficManagement/Record/SPF.php
@@ -2,12 +2,12 @@
 
 namespace Dyn\TrafficManagement\Record;
 
-class SOA extends AbstractRecord
+class SPF extends AbstractRecord
 {
     /**
      * @var string
      */
-    protected $type = 'SOA';
+    protected $type = 'SPF';
 
     /**
      * SPF record information, e.g.: v=spfl mx ptr -all


### PR DESCRIPTION
There was some typo's during composer --optimize I would get

```
Warning: Ambiguous class resolution, "Dyn\TrafficManagement\Record\NAPTR" was found in both "/var/www/html/nacms/vendor/dyninc/dyn-php/src/TrafficManagement/Record/NAPTR.php" and "/var/www/html/nacms/vendor/dyninc/dyn-php/src/TrafficManagement/Record/PX.php", the first will be used.
Warning: Ambiguous class resolution, "Dyn\TrafficManagement\Record\SOA" was found in both "/var/www/html/nacms/vendor/dyninc/dyn-php/src/TrafficManagement/Record/SOA.php" and "/var/www/html/nacms/vendor/dyninc/dyn-php/src/TrafficManagement/Record/SPF.php", the first will be used.
```